### PR TITLE
Badget alignment

### DIFF
--- a/dist/HorizontalServerList.css
+++ b/dist/HorizontalServerList.css
@@ -287,3 +287,13 @@ html.platform-osx #app-mount #pluginNotice {
 body.foldercontentopened .base-3dtUhz {
   transition: 0.2s ease !important;
 }
+
+/* Badges alignment */
+.upperBadge-2XnnGB {
+  top: -1px;
+  right: -1px;
+}
+.lowerBadge-29hYVK {
+  bottom: -1px;
+  right: -1px;
+}


### PR DESCRIPTION
is a little detail, the badges are too close to server
- Default
![Discord_V7SmHU4Si0](https://user-images.githubusercontent.com/79029257/131592915-01fe7b68-2b4f-4b5b-8894-56be78c00cbb.png)
![Discord_GxbvFgGsGC](https://user-images.githubusercontent.com/79029257/131592917-f83c276e-40e7-41c1-9056-da86d1325ca2.png)
- Alignment
![Discord_KjUkjTSwzu](https://user-images.githubusercontent.com/79029257/131592939-bb19d276-fc1c-438a-bf2d-bf9078b965b7.png)
![Discord_iASnKDDJX2](https://user-images.githubusercontent.com/79029257/131592940-23a98348-0055-4690-902b-5e625c3fcc50.png)
