### PR TITLE
Fix list item tooltip class selector

### DIFF
--- a/src/addons/_bottomhsl.scss
+++ b/src/addons/_bottomhsl.scss
@@ -24,7 +24,7 @@ body #app-mount {
 			bottom: calc(var(--server-container) * 2) !important;
 		}
 	}
-	[class*='listItemTooltip'] {
+	[class*='listItemTooltip_'] {
 		position: absolute;
 		white-space: nowrap;
 		top: calc(var(--server-size) / -1 - 30px) !important;

--- a/src/theme/_index.scss
+++ b/src/theme/_index.scss
@@ -146,7 +146,7 @@
 			top: 0 !important;
 		}
 	}
-	[class*='listItemTooltip'] {
+	[class*='listItemTooltip_'] {
 		position: absolute;
 		max-width: unset;
 		white-space: nowrap;


### PR DESCRIPTION
This change prevents us from modifying .listItemTooltipContent style, which breaks tooltips after a recent Discord update.