### PR TITLE
Fix gap when viewing streams in fullscreen

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -3,7 +3,7 @@
 	--serverlist-offset: var(--custom-guild-list-width);
 }
 
-.content_c48ade {
+.base_c48ade[data-fullscreen="false"] .content_c48ade {
 	margin-top: var(--serverlist-offset);
 	overflow: visible !important;
 }


### PR DESCRIPTION
Fixes the gap seen here:
![Discord_MzxTZZM3KH](https://github.com/user-attachments/assets/91a8417a-7984-414d-9576-da3992770d38)
