### PR TITLE
Fix notification message tray

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -31,10 +31,12 @@
 		rotate: 90deg;
 	}
 
-	.itemsContainer_ef3116,
-	.stack_dbd263 {
-		flex-direction: var(--HSL-server-direction);
-		justify-content: var(--HSL-server-alignment);
+	ul[data-list-id=guildsnav] {
+		.itemsContainer_ef3116,
+		.stack_dbd263 {
+			flex-direction: var(--HSL-server-direction);
+			justify-content: var(--HSL-server-alignment);
+		}
 	}
 
 	// Notices


### PR DESCRIPTION
Discord recently added a `stack_dbd263`-based message notification tray in the server list, which gets mangled by these two css rules.

`[data-list-id=guildsnav]` was used in the past, and i'm not certain why it's removed. This appears to fix it.
For some reason `div:not(.messageContainer_cb862a)` would not work.